### PR TITLE
Use $document instead of $cookies

### DIFF
--- a/angular-authentication-service.js
+++ b/angular-authentication-service.js
@@ -28,13 +28,17 @@
       configuration = _.defaults(configurationOpts, configuration);
     };
 
-    this.$get = ['$cookies', '$cookieStore', '$location', '$rootScope', '$store', function ($cookies, $cookieStore, $location, $rootScope, $store) {
+    this.$get = [
+    '$cookieStore', '$document', '$location', '$rootScope', '$store',
+    function ($cookieStore, $document, $location, $rootScope, $store) {
       return {
         /**
          * returns true if there is a user profile in storage.
          */
         isAuthenticated: function() {
-          if (configuration.authCookieKey && !$cookies[configuration.authCookieKey]) {
+          if (configuration.authCookieKey &&
+            (_.isEmpty($document.cookie) || $document.cookie.indexOf(configuration.authCookieKey) < 0)
+          ) {
             if ($store.has(configuration.profileStorageKey)) {
               // The cookie is absent or expired but we still have the profile stored.
               // Clear the profile and broadcast logout to ensure the app updates.

--- a/spec/services.js
+++ b/spec/services.js
@@ -85,16 +85,16 @@ describe('services', function() {
 
         describe('that is set', function() {
           it('should return false if user.profile is not set in store',
-            inject(function ($authentication, $cookieStore, $store) {
-              $cookieStore.put('AUTH-COOKIE', 'Authorized');
+            inject(function ($authentication, $document, $store) {
+              $document.cookie = 'AUTH-COOKIE=Authorized';
               $store.has('user.profile').should.be.false; // jshint ignore:line
               $authentication.isAuthenticated().should.be.false; // jshint ignore:line
             })
           );
 
           it('should return true if user.profile is set in store',
-            inject(function ($authentication, $cookieStore, $store) {
-              $cookieStore.put('AUTH-COOKIE', 'Authorized');
+            inject(function ($authentication, $document, $store) {
+              $document.cookie = 'AUTH-COOKIE=Authorized';
               $store.set('user.profile', { roles: ['a', 'b', 'c'] });
               $authentication.isAuthenticated().should.be.true; // jshint ignore:line
             })


### PR DESCRIPTION
Turns out that $cookies uses a polling mechanism to find out if there are changes to the underlying document.cookie string. This doesn't jive well with this service as upstream callers are watching for changes to it and cause it to clear the profile should no cookie exist. The functionality is important to prevent the appearance of being signed in without actually being signed in.
